### PR TITLE
Remove vlcb manufacturer code

### DIFF
--- a/cbusdefs.cs
+++ b/cbusdefs.cs
@@ -101,6 +101,7 @@ namespace merg.cbus
     // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
     // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
     // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+    // Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 	public static class CbusDefs
 	{
@@ -210,7 +211,6 @@ namespace merg.cbus
 			public const int MANU_SPROG	=  44;	// https://www.sprog-dcc.co.uk/
 			public const int MANU_ROCRAIL	=  70;	// http://www.rocrail.net
 			public const int MANU_SPECTRUM	=  80;	// http://animatedmodeler.com  (Spectrum Engineering)
-			public const int MANU_VLCB	=  250;	// VLCB range of modules
 			public const int MANU_SYSPIXIE	=  249;	// Konrad Orlowski
 			public const int MANU_RME	=  248;	// http://rmeuk.com  (Railway Modelling Experts Limited)
 		}
@@ -307,6 +307,7 @@ namespace merg.cbus
 			public const int MTYP_CANLEVER	=  80;	// Lever frame module (Tim Coombs)
 			public const int MTYP_CANSHIELD	=  81;	// Kit 110 Arduino shield test firmware
 			public const int MTYP_CAN4IN4OUT	=  82;	// 4 inputs 4 outputs (Arduino module)
+			public const int MTYP_CANARGB	=  83;	// Addressable LEDs
 			// 
 			// At the time of writing the list of defined MERG module types is maintained by Pete Brownlow software@upsys.co.uk
 			// Please liaise with Pete before adding new module types, 
@@ -549,6 +550,7 @@ namespace merg.cbus
 			public const int PF_BOOT	=  8;	// Module supports the FCU bootloader protocol
 			public const int PF_COE	=  16;	// Module can consume its own events
 			public const int PF_LRN	=  32;	// Module is in learn mode
+			public const int PF_VLCB	=  64;	// Module is VLCB compatible
 		}
 
 		public static class CbusParamOffsetsPic

--- a/cbusdefs.cs
+++ b/cbusdefs.cs
@@ -304,6 +304,8 @@ namespace merg.cbus
 			public const int MTYP_CANSBIP	=  78;	// Q series PIC input module (Ian Hart)
 			public const int MTYP_CANBUFFER	=  79;	// Message buffer (Phil Silver)
 			public const int MTYP_CANLEVER	=  80;	// Lever frame module (Tim Coombs)
+			public const int MTYP_CANSHIELD	=  81;	// Kit 110 Arduino shield test firmware
+			public const int MTYP_CAN4IN4OUT	=  82;	// 4 inputs 4 outputs (Arduino module)
 			// 
 			// At the time of writing the list of defined MERG module types is maintained by Pete Brownlow software@upsys.co.uk
 			// Please liaise with Pete before adding new module types, 
@@ -312,6 +314,7 @@ namespace merg.cbus
 			public const int MTYP_CAN_SW	=  0xFF;	// Software nodes
 			public const int MTYP_EMPTY	=  0xFE;	// Empty module, bootloader only
 			public const int MTYP_CANUSB	=  0xFD;	// USB interface
+			public const int MTYP_CANDEV	=  0xFC;	// Module type for use by developers when developing something new
 		}
 
 		public static class CbusMicrochipProcessors

--- a/cbusdefs.cs
+++ b/cbusdefs.cs
@@ -10,7 +10,7 @@ namespace merg.cbus
     // Originally derived from opcodes.h (c) Andrew Crosland.
     // CSV version by Ian Hogg inspired by David W Radcliffe
     // 
-    // Ver 8w 
+    // Ver 8y 
     // 
     //   This work is licensed under the:
     //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -100,6 +100,7 @@ namespace merg.cbus
     // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
     // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
     // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+    // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 	public static class CbusDefs
 	{

--- a/cbusdefs.csv
+++ b/cbusdefs.csv
@@ -94,6 +94,7 @@ comment,,,Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a
 comment,,,Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 comment,,,Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 comment,,,Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+comment,,,Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required.
 
 CbusManufacturer,,,CBUS Manufacturer definitions
 CbusManufacturer,,,Where the manufacturer already has an NMRA code, this is used
@@ -103,7 +104,6 @@ CbusManufacturer,MANU_MERG,165,https://www.merg.co.uk
 CbusManufacturer,MANU_SPROG,44,https://www.sprog-dcc.co.uk/
 CbusManufacturer,MANU_ROCRAIL,70,http://www.rocrail.net
 CbusManufacturer,MANU_SPECTRUM,80,http://animatedmodeler.com  (Spectrum Engineering)
-CbusManufacturer,MANU_MERG_VLCB,250,range of MERG VLCB modules
 CbusManufacturer,MANU_SYSPIXIE,249,Konrad Orlowski
 CbusManufacturer,MANU_RME,248,http://rmeuk.com  (Railway Modelling Experts Limited)
 

--- a/cbusdefs.csv
+++ b/cbusdefs.csv
@@ -3,7 +3,7 @@ comment,,,Copyright (C) Pete Brownlow 2011-2022   software@upsys.co.uk
 comment,,,Originally derived from opcodes.h (c) Andrew Crosland.
 comment,,,CSV version by Ian Hogg inspired by David W Radcliffe
 comment,,,
-comment,,,Ver 8w 
+comment,,,Ver 8y 
 comment,,,
 comment,,,  This work is licensed under the:
 comment,,,      Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -93,6 +93,7 @@ comment,,,Pete Brownlow,5/01/2023, Ver 8w  Add module type 80 for CANPMSense
 comment,,,Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 comment,,,Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 comment,,,Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+comment,,,Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 CbusManufacturer,,,CBUS Manufacturer definitions
 CbusManufacturer,,,Where the manufacturer already has an NMRA code, this is used

--- a/cbusdefs.csv
+++ b/cbusdefs.csv
@@ -103,7 +103,7 @@ CbusManufacturer,MANU_MERG,165,https://www.merg.co.uk
 CbusManufacturer,MANU_SPROG,44,https://www.sprog-dcc.co.uk/
 CbusManufacturer,MANU_ROCRAIL,70,http://www.rocrail.net
 CbusManufacturer,MANU_SPECTRUM,80,http://animatedmodeler.com  (Spectrum Engineering)
-CbusManufacturer,MANU_VLCB,250,VLCB range of modules
+CbusManufacturer,MANU_MERG_VLCB,250,range of MERG VLCB modules
 CbusManufacturer,MANU_SYSPIXIE,249,Konrad Orlowski
 CbusManufacturer,MANU_RME,248,http://rmeuk.com  (Railway Modelling Experts Limited)
 
@@ -526,6 +526,7 @@ CbusParamFlags,PF_FLiM,4,Module is in FLiM
 CbusParamFlags,PF_BOOT,8,Module supports the FCU bootloader protocol
 CbusParamFlags,PF_COE,16,Module can consume its own events
 CbusParamFlags,PF_LRN,32,Module is in learn mode
+CbusParamFlags,PF_VLCB,64,Module is VLCB compatible
 CbusBusTypes,,,
 CbusBusTypes,,,BUS type that module is connected to
 CbusBusTypes,,,

--- a/cbusdefs.csv
+++ b/cbusdefs.csv
@@ -194,6 +194,8 @@ CbusMergModuleTypes,MTYP_CANSOUT,77,Q series PIC input module (Ian Hart)
 CbusMergModuleTypes,MTYP_CANSBIP,78,Q series PIC input module (Ian Hart)
 CbusMergModuleTypes,MTYP_CANBUFFER,79,Message buffer (Phil Silver)
 CbusMergModuleTypes,MTYP_CANLEVER,80,Lever frame module (Tim Coombs)
+CbusMergModuleTypes,MTYP_CANSHIELD,81,Kit 110 Arduino shield test firmware
+CbusMergModuleTypes,MTYP_CAN4IN4OUT,82,4 inputs 4 outputs (Arduino module)
 
 
 CbusMergModuleTypes,,,
@@ -204,6 +206,7 @@ CbusMergModuleTypes,,,
 CbusMergModuleTypes,MTYP_CAN_SW,0xFF,Software nodes
 CbusMergModuleTypes,MTYP_EMPTY,0xFE,Empty module, bootloader only
 CbusMergModuleTypes,MTYP_CANUSB,0xFD,USB interface
+CbusMergModuleTypes,MTYP_CANDEV,0xFC,Module type for use by developers when developing something new
 CbusSprogModuleTypes,,,
 CbusSprogModuleTypes,,,Sprog Module types
 CbusSprogModuleTypes,,,

--- a/cbusdefs.csv
+++ b/cbusdefs.csv
@@ -94,7 +94,7 @@ comment,,,Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a
 comment,,,Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 comment,,,Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 comment,,,Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
-comment,,,Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required.
+comment,,,Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 CbusManufacturer,,,CBUS Manufacturer definitions
 CbusManufacturer,,,Where the manufacturer already has an NMRA code, this is used
@@ -197,6 +197,7 @@ CbusMergModuleTypes,MTYP_CANBUFFER,79,Message buffer (Phil Silver)
 CbusMergModuleTypes,MTYP_CANLEVER,80,Lever frame module (Tim Coombs)
 CbusMergModuleTypes,MTYP_CANSHIELD,81,Kit 110 Arduino shield test firmware
 CbusMergModuleTypes,MTYP_CAN4IN4OUT,82,4 inputs 4 outputs (Arduino module)
+CbusMergModuleTypes,MTYP_CANARGB,83,Addressable LEDs
 
 
 CbusMergModuleTypes,,,

--- a/cbusdefs.h
+++ b/cbusdefs.h
@@ -104,6 +104,7 @@ extern "C" {
 // 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// 		Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 // 
 // CBUS Manufacturer definitions
 // Where the manufacturer already has an NMRA code, this is used
@@ -113,7 +114,6 @@ extern "C" {
 #define MANU_SPROG	44	// https://www.sprog-dcc.co.uk/
 #define MANU_ROCRAIL	70	// http://www.rocrail.net
 #define MANU_SPECTRUM	80	// http://animatedmodeler.com  (Spectrum Engineering)
-#define MANU_VLCB	250	// VLCB range of modules
 #define MANU_SYSPIXIE	249	// Konrad Orlowski
 #define MANU_RME	248	// http://rmeuk.com  (Railway Modelling Experts Limited)
 // 
@@ -207,6 +207,7 @@ extern "C" {
 #define MTYP_CANLEVER	80	// Lever frame module (Tim Coombs)
 #define MTYP_CANSHIELD	81	// Kit 110 Arduino shield test firmware
 #define MTYP_CAN4IN4OUT	82	// 4 inputs 4 outputs (Arduino module)
+#define MTYP_CANARGB	83	// Addressable LEDs
 // 
 // 
 // 
@@ -536,6 +537,7 @@ extern "C" {
 #define PF_BOOT	8	// Module supports the FCU bootloader protocol
 #define PF_COE	16	// Module can consume its own events
 #define PF_LRN	32	// Module is in learn mode
+#define PF_VLCB	64	// Module is VLCB compatible
 // 
 // BUS type that module is connected to
 // 

--- a/cbusdefs.h
+++ b/cbusdefs.h
@@ -13,7 +13,7 @@ extern "C" {
 // 		Originally derived from opcodes.h (c) Andrew Crosland.
 // 		CSV version by Ian Hogg inspired by David W Radcliffe
 // 		
-// 		Ver 8w 
+// 		Ver 8y 
 // 		
 // 		  This work is licensed under the:
 // 		      Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -103,6 +103,7 @@ extern "C" {
 // 		Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 // 
 // CBUS Manufacturer definitions
 // Where the manufacturer already has an NMRA code, this is used

--- a/cbusdefs.h
+++ b/cbusdefs.h
@@ -204,6 +204,8 @@ extern "C" {
 #define MTYP_CANSBIP	78	// Q series PIC input module (Ian Hart)
 #define MTYP_CANBUFFER	79	// Message buffer (Phil Silver)
 #define MTYP_CANLEVER	80	// Lever frame module (Tim Coombs)
+#define MTYP_CANSHIELD	81	// Kit 110 Arduino shield test firmware
+#define MTYP_CAN4IN4OUT	82	// 4 inputs 4 outputs (Arduino module)
 // 
 // 
 // 
@@ -214,6 +216,7 @@ extern "C" {
 #define MTYP_CAN_SW	0xFF	// Software nodes
 #define MTYP_EMPTY	0xFE	// Empty module, bootloader only
 #define MTYP_CANUSB	0xFD	// USB interface
+#define MTYP_CANDEV	0xFC	// Module type for use by developers when developing something new
 // 
 // Sprog Module types
 // 

--- a/cbusdefs.inc
+++ b/cbusdefs.inc
@@ -97,6 +97,7 @@
 ; 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 ; 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 ; 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+; 		Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 ; 
 ; CBUS Manufacturer definitions
 ; Where the manufacturer already has an NMRA code, this is used
@@ -106,7 +107,6 @@ MANU_MERG	equ .165	; https://www.merg.co.uk
 MANU_SPROG	equ .44	; https://www.sprog-dcc.co.uk/
 MANU_ROCRAIL	equ .70	; http://www.rocrail.net
 MANU_SPECTRUM	equ .80	; http://animatedmodeler.com  (Spectrum Engineering)
-MANU_VLCB	equ .250	; VLCB range of modules
 MANU_SYSPIXIE	equ .249	; Konrad Orlowski
 MANU_RME	equ .248	; http://rmeuk.com  (Railway Modelling Experts Limited)
 ; 
@@ -200,6 +200,7 @@ MTYP_CANBUFFER	equ .79	; Message buffer (Phil Silver)
 MTYP_CANLEVER	equ .80	; Lever frame module (Tim Coombs)
 MTYP_CANSHIELD	equ .81	; Kit 110 Arduino shield test firmware
 MTYP_CAN4IN4OUT	equ .82	; 4 inputs 4 outputs (Arduino module)
+MTYP_CANARGB	equ .83	; Addressable LEDs
 ; 
 ; 
 ; 
@@ -529,6 +530,7 @@ PF_FLiM	equ .4	; Module is in FLiM
 PF_BOOT	equ .8	; Module supports the FCU bootloader protocol
 PF_COE	equ .16	; Module can consume its own events
 PF_LRN	equ .32	; Module is in learn mode
+PF_VLCB	equ .64	; Module is VLCB compatible
 ; 
 ; BUS type that module is connected to
 ; 

--- a/cbusdefs.inc
+++ b/cbusdefs.inc
@@ -197,6 +197,8 @@ MTYP_CANSOUT	equ .77	; Q series PIC input module (Ian Hart)
 MTYP_CANSBIP	equ .78	; Q series PIC input module (Ian Hart)
 MTYP_CANBUFFER	equ .79	; Message buffer (Phil Silver)
 MTYP_CANLEVER	equ .80	; Lever frame module (Tim Coombs)
+MTYP_CANSHIELD	equ .81	; Kit 110 Arduino shield test firmware
+MTYP_CAN4IN4OUT	equ .82	; 4 inputs 4 outputs (Arduino module)
 ; 
 ; 
 ; 
@@ -207,6 +209,7 @@ MTYP_CANLEVER	equ .80	; Lever frame module (Tim Coombs)
 MTYP_CAN_SW	equ 0xFF	; Software nodes
 MTYP_EMPTY	equ 0xFE	; Empty module, bootloader only
 MTYP_CANUSB	equ 0xFD	; USB interface
+MTYP_CANDEV	equ 0xFC	; Module type for use by developers when developing something new
 ; 
 ; Sprog Module types
 ; 

--- a/cbusdefs.inc
+++ b/cbusdefs.inc
@@ -6,7 +6,7 @@
 ; 		Originally derived from opcodes.h (c) Andrew Crosland.
 ; 		CSV version by Ian Hogg inspired by David W Radcliffe
 ; 		
-; 		Ver 8w 
+; 		Ver 8y 
 ; 		
 ; 		  This work is licensed under the:
 ; 		      Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -96,6 +96,7 @@
 ; 		Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 ; 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 ; 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+; 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 ; 
 ; CBUS Manufacturer definitions
 ; Where the manufacturer already has an NMRA code, this is used

--- a/cbusdefs.pas
+++ b/cbusdefs.pas
@@ -103,6 +103,7 @@ const
 { 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs) }
 { 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland) }
 { 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV }
+{ 		Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB. }
 // 
 // CBUS Manufacturer definitions
 // Where the manufacturer already has an NMRA code, this is used
@@ -112,7 +113,6 @@ const
  MANU_SPROG	=  44;	// https://www.sprog-dcc.co.uk/
  MANU_ROCRAIL	=  70;	// http://www.rocrail.net
  MANU_SPECTRUM	=  80;	// http://animatedmodeler.com  (Spectrum Engineering)
- MANU_VLCB	=  250;	// VLCB range of modules
  MANU_SYSPIXIE	=  249;	// Konrad Orlowski
  MANU_RME	=  248;	// http://rmeuk.com  (Railway Modelling Experts Limited)
 // 
@@ -206,6 +206,7 @@ const
  MTYP_CANLEVER	=  80;	// Lever frame module (Tim Coombs)
  MTYP_CANSHIELD	=  81;	// Kit 110 Arduino shield test firmware
  MTYP_CAN4IN4OUT	=  82;	// 4 inputs 4 outputs (Arduino module)
+ MTYP_CANARGB	=  83;	// Addressable LEDs
 // 
 // 
 // 
@@ -535,6 +536,7 @@ const
  PF_BOOT	=  8;	// Module supports the FCU bootloader protocol
  PF_COE	=  16;	// Module can consume its own events
  PF_LRN	=  32;	// Module is in learn mode
+ PF_VLCB	=  64;	// Module is VLCB compatible
 // 
 // BUS type that module is connected to
 // 

--- a/cbusdefs.pas
+++ b/cbusdefs.pas
@@ -203,6 +203,8 @@ const
  MTYP_CANSBIP	=  78;	// Q series PIC input module (Ian Hart)
  MTYP_CANBUFFER	=  79;	// Message buffer (Phil Silver)
  MTYP_CANLEVER	=  80;	// Lever frame module (Tim Coombs)
+ MTYP_CANSHIELD	=  81;	// Kit 110 Arduino shield test firmware
+ MTYP_CAN4IN4OUT	=  82;	// 4 inputs 4 outputs (Arduino module)
 // 
 // 
 // 
@@ -213,6 +215,7 @@ const
  MTYP_CAN_SW	=  0xFF;	// Software nodes
  MTYP_EMPTY	=  0xFE;	// Empty module, bootloader only
  MTYP_CANUSB	=  0xFD;	// USB interface
+ MTYP_CANDEV	=  0xFC;	// Module type for use by developers when developing something new
 // 
 // Sprog Module types
 // 

--- a/cbusdefs.pas
+++ b/cbusdefs.pas
@@ -12,7 +12,7 @@ const
 { 		Originally derived from opcodes.h (c) Andrew Crosland. }
 { 		CSV version by Ian Hogg inspired by David W Radcliffe }
 { 		 }
-{ 		Ver 8w  }
+{ 		Ver 8y  }
 { 		 }
 { 		  This work is licensed under the: }
 { 		      Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. }
@@ -102,6 +102,7 @@ const
 { 		Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo }
 { 		Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs) }
 { 		Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland) }
+{ 		Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV }
 // 
 // CBUS Manufacturer definitions
 // Where the manufacturer already has an NMRA code, this is used

--- a/cbusdefs.py
+++ b/cbusdefs.py
@@ -100,6 +100,7 @@ from micropython import const
 #         Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 #         Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 #         Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+#         Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 # 
 # CBUS Manufacturer definitions
 # Where the manufacturer already has an NMRA code, this is used
@@ -109,7 +110,6 @@ MANU_MERG = const(165)    # https://www.merg.co.uk
 MANU_SPROG = const(44)    # https://www.sprog-dcc.co.uk/
 MANU_ROCRAIL = const(70)    # http://www.rocrail.net
 MANU_SPECTRUM = const(80)    # http://animatedmodeler.com  (Spectrum Engineering)
-MANU_VLCB = const(250)    # VLCB range of modules
 MANU_SYSPIXIE = const(249)    # Konrad Orlowski
 MANU_RME = const(248)    # http://rmeuk.com  (Railway Modelling Experts Limited)
 # 
@@ -203,6 +203,7 @@ MTYP_CANBUFFER = const(79)    # Message buffer (Phil Silver)
 MTYP_CANLEVER = const(80)    # Lever frame module (Tim Coombs)
 MTYP_CANSHIELD = const(81)    # Kit 110 Arduino shield test firmware
 MTYP_CAN4IN4OUT = const(82)    # 4 inputs 4 outputs (Arduino module)
+MTYP_CANARGB = const(83)    # Addressable LEDs
 # 
 # 
 # 
@@ -532,6 +533,7 @@ PF_FLiM = const(4)    # Module is in FLiM
 PF_BOOT = const(8)    # Module supports the FCU bootloader protocol
 PF_COE = const(16)    # Module can consume its own events
 PF_LRN = const(32)    # Module is in learn mode
+PF_VLCB = const(64)    # Module is VLCB compatible
 # 
 # BUS type that module is connected to
 # 

--- a/cbusdefs.py
+++ b/cbusdefs.py
@@ -9,7 +9,7 @@ from micropython import const
 #         Originally derived from opcodes.h (c) Andrew Crosland.
 #         CSV version by Ian Hogg inspired by David W Radcliffe
 #         
-#         Ver 8w 
+#         Ver 8y 
 #         
 #           This work is licensed under the:
 #               Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ from micropython import const
 #         Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 #         Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 #         Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+#         Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 # 
 # CBUS Manufacturer definitions
 # Where the manufacturer already has an NMRA code, this is used

--- a/cbusdefs.py
+++ b/cbusdefs.py
@@ -200,6 +200,8 @@ MTYP_CANSOUT = const(77)    # Q series PIC input module (Ian Hart)
 MTYP_CANSBIP = const(78)    # Q series PIC input module (Ian Hart)
 MTYP_CANBUFFER = const(79)    # Message buffer (Phil Silver)
 MTYP_CANLEVER = const(80)    # Lever frame module (Tim Coombs)
+MTYP_CANSHIELD = const(81)    # Kit 110 Arduino shield test firmware
+MTYP_CAN4IN4OUT = const(82)    # 4 inputs 4 outputs (Arduino module)
 # 
 # 
 # 
@@ -210,6 +212,7 @@ MTYP_CANLEVER = const(80)    # Lever frame module (Tim Coombs)
 MTYP_CAN_SW = const(0xFF)    # Software nodes
 MTYP_EMPTY = const(0xFE)    # Empty module, bootloader only
 MTYP_CANUSB = const(0xFD)    # USB interface
+MTYP_CANDEV = const(0xFC)    # Module type for use by developers when developing something new
 # 
 # Sprog Module types
 # 

--- a/cbusdefsenums.cs
+++ b/cbusdefsenums.cs
@@ -667,6 +667,14 @@ namespace Merg.Cbus
 		/// </summary>
 		Canlever = 80,
 		/// <summary>
+		/// Kit 110 Arduino shield test firmware
+		/// </summary>
+		Canshield = 81,
+		/// <summary>
+		/// 4 inputs 4 outputs (Arduino module)
+		/// </summary>
+		Can4in4out = 82,
+		/// <summary>
 		/// Software nodes
 		/// </summary>
 		CanSw = 0xFF,
@@ -678,6 +686,10 @@ namespace Merg.Cbus
 		/// USB interface
 		/// </summary>
 		Canusb = 0xFD,
+		/// <summary>
+		/// Module type for use by developers when developing something new
+		/// </summary>
+		Candev = 0xFC,
 	}
 
 	/// <summary>

--- a/cbusdefsenums.cs
+++ b/cbusdefsenums.cs
@@ -10,7 +10,7 @@ namespace Merg.Cbus
     // Originally derived from opcodes.h (c) Andrew Crosland.
     // CSV version by Ian Hogg inspired by David W Radcliffe
     // 
-    // Ver 8w 
+    // Ver 8y 
     // 
     //   This work is licensed under the:
     //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -100,6 +100,7 @@ namespace Merg.Cbus
     // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
     // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
     // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+    // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 	/// <summary>
 	/// 

--- a/cbusdefsenums.cs
+++ b/cbusdefsenums.cs
@@ -101,6 +101,7 @@ namespace Merg.Cbus
     // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
     // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
     // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+    // Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 	/// <summary>
 	/// 
@@ -324,10 +325,6 @@ namespace Merg.Cbus
 		/// http://animatedmodeler.com  (Spectrum Engineering)
 		/// </summary>
 		Spectrum = 80,
-		/// <summary>
-		/// VLCB range of modules
-		/// </summary>
-		Vlcb = 250,
 		/// <summary>
 		/// Konrad Orlowski
 		/// </summary>
@@ -675,6 +672,10 @@ namespace Merg.Cbus
 		/// 4 inputs 4 outputs (Arduino module)
 		/// </summary>
 		Can4in4out = 82,
+		/// <summary>
+		/// Addressable LEDs
+		/// </summary>
+		Canargb = 83,
 		/// <summary>
 		/// Software nodes
 		/// </summary>
@@ -1408,6 +1409,10 @@ namespace Merg.Cbus
 		/// Module is in learn mode
 		/// </summary>
 		Lrn = 32,
+		/// <summary>
+		/// Module is VLCB compatible
+		/// </summary>
+		Vlcb = 64,
 	}
 
 	/// <summary>

--- a/java/uk/org/merg/cbus/CbusArmProcessors.java
+++ b/java/uk/org/merg/cbus/CbusArmProcessors.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusArmProcessors {
 // 

--- a/java/uk/org/merg/cbus/CbusArmProcessors.java
+++ b/java/uk/org/merg/cbus/CbusArmProcessors.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusArmProcessors {
 // 

--- a/java/uk/org/merg/cbus/CbusBusTypes.java
+++ b/java/uk/org/merg/cbus/CbusBusTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusBusTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusBusTypes.java
+++ b/java/uk/org/merg/cbus/CbusBusTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusBusTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect0.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect0.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusCabSigAspect0 {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect0.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect0.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusCabSigAspect0 {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect1.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect1.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusCabSigAspect1 {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect1.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect1.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusCabSigAspect1 {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect2.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect2.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusCabSigAspect2 {
 // 

--- a/java/uk/org/merg/cbus/CbusCabSigAspect2.java
+++ b/java/uk/org/merg/cbus/CbusCabSigAspect2.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusCabSigAspect2 {
 // 

--- a/java/uk/org/merg/cbus/CbusCmdErrs.java
+++ b/java/uk/org/merg/cbus/CbusCmdErrs.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusCmdErrs {
 // 

--- a/java/uk/org/merg/cbus/CbusCmdErrs.java
+++ b/java/uk/org/merg/cbus/CbusCmdErrs.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusCmdErrs {
 // 

--- a/java/uk/org/merg/cbus/CbusErrs.java
+++ b/java/uk/org/merg/cbus/CbusErrs.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusErrs {
 // 

--- a/java/uk/org/merg/cbus/CbusErrs.java
+++ b/java/uk/org/merg/cbus/CbusErrs.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusErrs {
 // 

--- a/java/uk/org/merg/cbus/CbusManufacturer.java
+++ b/java/uk/org/merg/cbus/CbusManufacturer.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusManufacturer {
 // CBUS Manufacturer definitions
@@ -110,7 +111,6 @@ public enum CbusManufacturer {
 	MANU_SPROG(44),	//https://www.sprog-dcc.co.uk/
 	MANU_ROCRAIL(70),	//http://www.rocrail.net
 	MANU_SPECTRUM(80),	//http://animatedmodeler.com  (Spectrum Engineering)
-	MANU_VLCB(250),	//VLCB range of modules
 	MANU_SYSPIXIE(249),	//Konrad Orlowski
 	MANU_RME(248);	//http://rmeuk.com  (Railway Modelling Experts Limited)
 

--- a/java/uk/org/merg/cbus/CbusManufacturer.java
+++ b/java/uk/org/merg/cbus/CbusManufacturer.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusManufacturer {
 // CBUS Manufacturer definitions

--- a/java/uk/org/merg/cbus/CbusMergModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusMergModuleTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusMergModuleTypes {
 // 
@@ -192,6 +193,7 @@ public enum CbusMergModuleTypes {
 	MTYP_CANLEVER(80),	//Lever frame module (Tim Coombs)
 	MTYP_CANSHIELD(81),	//Kit 110 Arduino shield test firmware
 	MTYP_CAN4IN4OUT(82),	//4 inputs 4 outputs (Arduino module)
+	MTYP_CANARGB(83),	//Addressable LEDs
 // 
 // At the time of writing the list of defined MERG module types is maintained by Pete Brownlow software@upsys.co.uk
 // Please liaise with Pete before adding new module types, 

--- a/java/uk/org/merg/cbus/CbusMergModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusMergModuleTypes.java
@@ -189,6 +189,8 @@ public enum CbusMergModuleTypes {
 	MTYP_CANSBIP(78),	//Q series PIC input module (Ian Hart)
 	MTYP_CANBUFFER(79),	//Message buffer (Phil Silver)
 	MTYP_CANLEVER(80),	//Lever frame module (Tim Coombs)
+	MTYP_CANSHIELD(81),	//Kit 110 Arduino shield test firmware
+	MTYP_CAN4IN4OUT(82),	//4 inputs 4 outputs (Arduino module)
 // 
 // At the time of writing the list of defined MERG module types is maintained by Pete Brownlow software@upsys.co.uk
 // Please liaise with Pete before adding new module types, 
@@ -196,7 +198,8 @@ public enum CbusMergModuleTypes {
 // 
 	MTYP_CAN_SW(0xFF),	//Software nodes
 	MTYP_EMPTY(0xFE),	//Empty module, bootloader only
-	MTYP_CANUSB(0xFD);	//USB interface
+	MTYP_CANUSB(0xFD),	//USB interface
+	MTYP_CANDEV(0xFC);	//Module type for use by developers when developing something new
 
 	private final int v;
 

--- a/java/uk/org/merg/cbus/CbusMergModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusMergModuleTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusMergModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusMicrochipProcessors.java
+++ b/java/uk/org/merg/cbus/CbusMicrochipProcessors.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusMicrochipProcessors {
 // 

--- a/java/uk/org/merg/cbus/CbusMicrochipProcessors.java
+++ b/java/uk/org/merg/cbus/CbusMicrochipProcessors.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusMicrochipProcessors {
 // 

--- a/java/uk/org/merg/cbus/CbusOpCodes.java
+++ b/java/uk/org/merg/cbus/CbusOpCodes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusOpCodes {
 // 

--- a/java/uk/org/merg/cbus/CbusOpCodes.java
+++ b/java/uk/org/merg/cbus/CbusOpCodes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusOpCodes {
 // 

--- a/java/uk/org/merg/cbus/CbusParamFlags.java
+++ b/java/uk/org/merg/cbus/CbusParamFlags.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusParamFlags {
 // 

--- a/java/uk/org/merg/cbus/CbusParamFlags.java
+++ b/java/uk/org/merg/cbus/CbusParamFlags.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusParamFlags {
 // 
@@ -112,7 +113,8 @@ public enum CbusParamFlags {
 	PF_FLiM(4),	//Module is in FLiM
 	PF_BOOT(8),	//Module supports the FCU bootloader protocol
 	PF_COE(16),	//Module can consume its own events
-	PF_LRN(32);	//Module is in learn mode
+	PF_LRN(32),	//Module is in learn mode
+	PF_VLCB(64);	//Module is VLCB compatible
 
 	private final int v;
 

--- a/java/uk/org/merg/cbus/CbusParamOffsetsPic.java
+++ b/java/uk/org/merg/cbus/CbusParamOffsetsPic.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusParamOffsetsPic {
 // 

--- a/java/uk/org/merg/cbus/CbusParamOffsetsPic.java
+++ b/java/uk/org/merg/cbus/CbusParamOffsetsPic.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusParamOffsetsPic {
 // 

--- a/java/uk/org/merg/cbus/CbusParams.java
+++ b/java/uk/org/merg/cbus/CbusParams.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusParams {
 // 

--- a/java/uk/org/merg/cbus/CbusParams.java
+++ b/java/uk/org/merg/cbus/CbusParams.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusParams {
 // 

--- a/java/uk/org/merg/cbus/CbusProcessorManufacturers.java
+++ b/java/uk/org/merg/cbus/CbusProcessorManufacturers.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusProcessorManufacturers {
 // 

--- a/java/uk/org/merg/cbus/CbusProcessorManufacturers.java
+++ b/java/uk/org/merg/cbus/CbusProcessorManufacturers.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusProcessorManufacturers {
 // 

--- a/java/uk/org/merg/cbus/CbusRocRailModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusRocRailModuleTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusRocRailModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusRocRailModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusRocRailModuleTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusRocRailModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusSStats.java
+++ b/java/uk/org/merg/cbus/CbusSStats.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusSStats {
 // 

--- a/java/uk/org/merg/cbus/CbusSStats.java
+++ b/java/uk/org/merg/cbus/CbusSStats.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusSStats {
 // 

--- a/java/uk/org/merg/cbus/CbusSpectrumModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSpectrumModuleTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusSpectrumModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusSpectrumModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSpectrumModuleTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusSpectrumModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusSprogModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSprogModuleTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusSprogModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusSprogModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSprogModuleTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusSprogModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusStmodModes.java
+++ b/java/uk/org/merg/cbus/CbusStmodModes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusStmodModes {
 // 

--- a/java/uk/org/merg/cbus/CbusStmodModes.java
+++ b/java/uk/org/merg/cbus/CbusStmodModes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusStmodModes {
 // 

--- a/java/uk/org/merg/cbus/CbusSysPixieModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSysPixieModuleTypes.java
@@ -100,6 +100,7 @@ package uk.org.merg.cbus;
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
 // Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
+// Ian Hogg, 10/3/25, Remove the VLCB manufacturer code as this is no longer required. Add CANARGB.
 
 public enum CbusSysPixieModuleTypes {
 // 

--- a/java/uk/org/merg/cbus/CbusSysPixieModuleTypes.java
+++ b/java/uk/org/merg/cbus/CbusSysPixieModuleTypes.java
@@ -9,7 +9,7 @@ package uk.org.merg.cbus;
 // Originally derived from opcodes.h (c) Andrew Crosland.
 // CSV version by Ian Hogg inspired by David W Radcliffe
 // 
-// Ver 8w 
+// Ver 8y 
 // 
 //   This work is licensed under the:
 //       Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -99,6 +99,7 @@ package uk.org.merg.cbus;
 // Ian Hogg,14/08/2023, Ver 8x  Add manufacturer code for VLCB. This is a way to allocate a block of module Id to VLCB even though VLCB group is not a manufacturer per se. The VLCB module IDs will be defined in the VLCB repo
 // Pete Brownlow,2/11/23, Ver 8x  Add module id for CANLEVER (Tim Coombs)
 // Pete Brownlow,3/11/23, Ver 8x  Update SPROG module type ids (Andrew Crosland)
+// Pete Brownlow, 23/11/23, Ver 8y  Add CANSHIELD, CAN4IN4OUT, CANDEV
 
 public enum CbusSysPixieModuleTypes {
 // 


### PR DESCRIPTION
The VLCB manufacturer code is no longer required as the VLCB parameter flag is used instead so this just removes the VLCB manufacturer code.